### PR TITLE
adding sample ignition file for coreOS 4.6

### DIFF
--- a/sample-ignition/default_password_coreOS46.ign
+++ b/sample-ignition/default_password_coreOS46.ign
@@ -1,0 +1,17 @@
+{
+  "ignition": {
+    "version": "3.1.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "passwordHash": "$6$SALT$7zs.MmuHvHSfpPomJQ7LfY0PJ8j9ZASIFD1lOvNkpJPhjqb.QeODaPhEHKPprcy1nfhw.XuvtJrYN4vOUqNtG1",
+        "sshAuthorizedKeys":[
+          "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDPCgcG1tKdgvddj80aWMvbndwS+pSLOq0ZQPQotshc7t1JRQqobHgSm8xoIoUW5rMEgW/KXZpGXVpCzHCSuqPMGYidMg+I1bND/4IgvlcdYXgpDTVybcxBE7il61ev35XMnbk6zB94m3nRxIk0s8NQrqEgW2J4itQrbLeNNCEbe+WepAIZnul4yPiN/urymfGgmn/a4vLzkvieabJQhmsQDYhKkn92R2zG+skFgfntVTlb19rN4315xFPF+RUINrn2hdGq6bfAWtJ6iA99LtuRQ16E0deYy5Gq03i3Oy8GGDq3BkTuyOSqDptuZLfiMmubmpz2MFSfzJrrVXr9C1lN2wtIC4S9CSD++ZbyKqTxB7DtVaHglPq/xeTJHhhiY+zDpGeaY1FZuRYVc7+ssmmSy0JhODRwbTDhsYjXLcygbEsd9t5gMlKLiLEmhik1VwJmvabpg4Tf/Mh7BGuKPCAwTUjj0Ms+/5jrnzz21DoI3tCtF+vMz/vTWI/9shMjunc= AzureAD+UserName@DESKTOP-DESKTOPID"
+	]
+      }
+    ]
+  }
+}
+


### PR DESCRIPTION
adding sample ignition file for RHCOS 4.6 to enable pswd login and ssh-key login.